### PR TITLE
add paster tasks to generate datasets and referrers CSV

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,5 +34,7 @@ setup(
         initdb = ckanext.ga_report.command:InitDB
         getauthtoken = ckanext.ga_report.command:GetAuthToken
         fixtimeperiods = ckanext.ga_report.command:FixTimePeriods
+        generatedatasetscsv = ckanext.ga_report.command:GenerateDatasetsCsv
+        generatereferrerscsv = ckanext.ga_report.command:GenerateReferrersCsv
 	""",
 )


### PR DESCRIPTION
Hey there all,

Here's a couple of extra paster tasks - one of which generates the datasets visits CSV (for use in the case where generating it on-request takes too long), and the other of which generates aggregate stats for the datasets with the most referred links, for all periods. 

These are both required for the data.gov.uk site analytics section refresh - they'll need to be run periodically by a cron job or similar, but will discuss this with you separately.

Cheers!

Tim
