### PR TITLE
fix dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+google-api-python-client==1.4.1
+oauth2client==1.4.12


### PR DESCRIPTION
google-api-python-client and oauth2client need to be fixed to the version before latest, since they introduced some changes that are breaking to ga-report