### PR TITLE
Fix download counts

### DIFF
--- a/ckanext/ga_report/download_analytics.py
+++ b/ckanext/ga_report/download_analytics.py
@@ -515,12 +515,10 @@ class DownloadAnalytics(object):
             results = dict(url=[])
         result_data = results.get('rows')
         if not result_data:
-            # We may not have data for this time period, so we need to bail
-            # early.
             log.info("There is no cached download data for this time period")
-            return
-        log.info('Associating cached downloads of resource URLs with their respective datasets')
-        process_result_data(results.get('rows'))
+        else:
+            log.info('Associating cached downloads of resource URLs with their respective datasets')
+            process_result_data(result_data)
 
         ga_model.update_sitewide_stats(period_name, "Downloads", data, period_complete_day)
 

--- a/ckanext/ga_report/download_analytics.py
+++ b/ckanext/ga_report/download_analytics.py
@@ -371,7 +371,7 @@ class DownloadAnalytics(object):
             args["end-date"] = end_date
             args["ids"] = "ga:" + self.profile_id
 
-            args["metrics"] = "ga:pageviewsPerVisit,ga:avgTimeOnSite,ga:percentNewVisits,ga:visits"
+            args["metrics"] = "ga:pageviewsPerVisit,ga:avgSessionDuration,ga:percentNewVisits,ga:visits"
             args["alt"] = "json"
 
             results = self._get_ga_data(args)


### PR DESCRIPTION
For some reason if there was no event count called "download-cache" the function would return and thus not produce any download counts. (It looks like that "bail out" code was copied from above, without checking).

The code is currently modified by hand on test, in order to check this works daily, so please don't merge and pull just yet.
